### PR TITLE
Add idkit_cuid2_generate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1272,6 +1272,7 @@ name = "pg_idkit"
 version = "0.1.0"
 dependencies = [
  "cuid",
+ "cuid2",
  "getrandom",
  "ksuid",
  "nanoid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ pg_test = []
 
 [dependencies]
 cuid = "1.3.1"
+cuid2 = "0.1.0"
 getrandom = "0.2.8"
 ksuid = "0.2.0"
 nanoid = "0.4.0"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@
 | [Timeflake][timeflake] | `idkit_timeflake_generate` | [`timeflake-rs`](https://crates.io/crates/timeflake-rs) | Twitter's Snowflake + Instagram's ID + Firebase's PushID |
 | [PushID][pushid]       | `idkit_pushid_generate`    | [`pushid`](https://crates.io/crates/pushid)             | Google Firebase's PushID                                 |
 | [xid][xid]             | `idkit_xid_generate`       | [`xid`](https://crates.io/crates/xid)                   | XID                                                      |
-| [cuid][cuid]           | `idkit_cuid_generate`      | [`cuid`](https://crates.io/crates/cuid)                 | CUID                                                     |
+| [cuid][cuid] (deprecated)           | `idkit_cuid_generate`      | [`cuid`](https://crates.io/crates/cuid)                 | CUID                                                     |
+| [cuid2][cuid2]           | `idkit_cuid2_generate`      | [`cuid2`](https://crates.io/crates/cuid2)                 | CUID                                                     |
 
 This Postgres extension is made possible thanks to [`pgrx`][pgrx].
 
@@ -161,7 +162,8 @@ To push up images that are used from continuous integration:
 [ksuid]: https://github.com/segmentio/ksuid
 [ulid]: https://github.com/ulid/spec
 [pushid]: https://firebase.googleblog.com/2015/02/the-2120-ways-to-ensure-unique_68.html
-[cuid]: https://github.com/ericelliott/cuid
+[cuid]: https://github.com/paralleldrive/cuid
+[cuid2]: https://github.com/paralleldrive/cuid2
 [xid]: https://github.com/rs/xid
 [objectid]: https://www.mongodb.com/docs/manual/reference/method/ObjectId/
 [nanoid]: https://www.npmjs.com/package/nanoid

--- a/src/cuid2.rs
+++ b/src/cuid2.rs
@@ -1,0 +1,31 @@
+use cuid2;
+use pgrx::*;
+
+/// Generate a random cuid2 UUID
+#[pg_extern]
+fn idkit_cuid2_generate() -> String {
+    cuid2::create_id()
+}
+
+/// Generate a random cuid UUID, producing a Postgres text object
+#[pg_extern]
+fn idkit_cuid2_generate_text() -> String {
+    idkit_cuid2_generate()
+}
+
+//////////
+// Test //
+//////////
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use pgrx::*;
+
+    /// Basic length test
+    #[pg_test]
+    fn test_cuid2_len() {
+        let generated = crate::cuid2::idkit_cuid2_generate();
+        assert_eq!(generated.len(), 24);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod timeflake;
 mod pushid;
 mod xid;
 mod cuid;
+mod cuid2;
 
 use pgrx::pg_module_magic;
 


### PR DESCRIPTION
Related to #19
cuid v1 is deprecated based on [official repo.](https://github.com/paralleldrive/cuid)

This pull request adds cuid2 generation by calling `idkit_cuid2_generate` function.

Also marked cuid as deprecated in README.md