### PR TITLE
feat: add functions for extracting timestamps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,6 +102,15 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
+]
+
+[[package]]
+name = "backtrace-ext"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+dependencies = [
+ "backtrace",
 ]
 
 [[package]]
@@ -239,17 +254,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-integer",
  "num-traits",
- "time",
  "wasm-bindgen",
- "winapi",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -862,6 +876,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "rustix 0.38.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "is_ci"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
+
+[[package]]
 name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,6 +969,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
+
+[[package]]
 name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,6 +1036,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miette"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
+dependencies = [
+ "backtrace",
+ "backtrace-ext",
+ "is-terminal",
+ "miette-derive",
+ "once_cell",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -1245,10 +1314,13 @@ dependencies = [
 name = "pg_idkit"
 version = "0.1.0"
 dependencies = [
+ "base36",
+ "chrono",
  "cuid",
  "cuid2",
  "getrandom",
  "ksuid",
+ "miette",
  "nanoid",
  "pgrx",
  "pgrx-tests",
@@ -1833,7 +1905,20 @@ dependencies = [
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.3.7",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
+dependencies = [
+ "bitflags 2.4.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.10",
  "windows-sys 0.48.0",
 ]
 
@@ -2005,6 +2090,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "socket2"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2071,6 +2162,34 @@ name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
+name = "supports-color"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
+dependencies = [
+ "is-terminal",
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84231692eb0d4d41e4cdd0cabfdd2e6cd9e255e65f80c9aa7c98dd502b4233d"
+dependencies = [
+ "is-terminal",
+]
+
+[[package]]
+name = "supports-unicode"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b6c2cb240ab5dd21ed4906895ee23fe5a48acdbd15a3ce388e7b62a9b66baf7"
+dependencies = [
+ "is-terminal",
+]
 
 [[package]]
 name = "syn"
@@ -2149,8 +2268,29 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix",
+ "rustix 0.37.19",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2365,6 +2505,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2378,6 +2524,12 @@ name = "unicode-segmentation"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,7 @@
 name = "pg_idkit"
 version = "0.1.0"
 edition = "2021"
-authors = [
-  "Victor Adossi <vados@vadosware.io>"
-]
+authors = ["Victor Adossi <vados@vadosware.io>"]
 rust-version = "1.73.0"
 description = """
 A Postgres extension for generating UUIDs
@@ -18,17 +16,19 @@ maintenance = { status = "actively-maintained" }
 
 [features]
 default = ["pg15"]
-pg11 = [ "pgrx/pg11", "pgrx-tests/pg11" ]
-pg12 = [ "pgrx/pg12", "pgrx-tests/pg12" ]
-pg13 = [ "pgrx/pg13", "pgrx-tests/pg13" ]
-pg14 = [ "pgrx/pg14", "pgrx-tests/pg14" ]
-pg15 = [ "pgrx/pg15", "pgrx-tests/pg15" ]
+pg11 = ["pgrx/pg11", "pgrx-tests/pg11"]
+pg12 = ["pgrx/pg12", "pgrx-tests/pg12"]
+pg13 = ["pgrx/pg13", "pgrx-tests/pg13"]
+pg14 = ["pgrx/pg14", "pgrx-tests/pg14"]
+pg15 = ["pgrx/pg15", "pgrx-tests/pg15"]
 pg_test = []
 
 [dependencies]
 cuid = "1.3.2"
 cuid2 = "0.1.2"
 getrandom = "0.2.10"
+base36 = "0.0.1"
+chrono = { version = "0.4.31", default-features = false, features = ["clock"] }
 ksuid = "0.2.0"
 nanoid = "0.4.0"
 pgrx = "=0.11.0"
@@ -38,6 +38,7 @@ timeflake-rs = "0.3.0"
 ulid = "1.1.0"
 uuid7 = "0.7.2"
 xid = "1.0.3"
+miette = { version = "5.10.0", features = ["fancy"] }
 
 [dev-dependencies]
 pgrx-tests = "=0.11.0"

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,0 +1,28 @@
+/// A trait that encapsulates things that can be converted to some type
+/// or to an error if conversion fails (ex. Result, Option, etc)
+pub(crate) trait OrPgxError<T> {
+    /// Convert the given type to a T, possibly failing
+    /// and calling [`pgrx::error`], with a given prefix if an error is returned
+    fn or_pgrx_error(self, prefix: impl AsRef<str>) -> T;
+}
+
+impl<T, E> OrPgxError<T> for Result<T, E>
+where
+    E: std::error::Error,
+{
+    fn or_pgrx_error(self, prefix: impl AsRef<str>) -> T {
+        match self {
+            Ok(v) => v,
+            Err(e) => pgrx::error!("{}: {e}", prefix.as_ref()),
+        }
+    }
+}
+
+impl<T> OrPgxError<T> for Option<T> {
+    fn or_pgrx_error(self, prefix: impl AsRef<str>) -> T {
+        match self {
+            Some(v) => v,
+            None => pgrx::error!("{}", prefix.as_ref()),
+        }
+    }
+}

--- a/src/cuid.rs
+++ b/src/cuid.rs
@@ -1,9 +1,19 @@
+use std::io;
+
+use chrono::{Datelike, NaiveDateTime, Timelike};
 use cuid;
 use pgrx::*;
+
+use crate::common::OrPgxError;
 
 /// Generate a random cuid UUID
 #[pg_extern]
 fn idkit_cuid_generate() -> String {
+    // Ignore the deprecated version here in case people are using cuid
+    warning!(
+        "cuid is deprecated in favor of cuid2, consider using cuid2 (also available in pg_idkit)"
+    );
+    #[allow(deprecated)]
     match cuid::cuid() {
         Err(e) => error!("failed to generate cuid: {}", e),
         Ok(id) => id,
@@ -16,6 +26,56 @@ fn idkit_cuid_generate_text() -> String {
     idkit_cuid_generate()
 }
 
+/// Retrieve a `timestamptz` from a given textual CUID
+///
+/// If the value is not a valid CUID, this function will throw an error
+#[pg_extern]
+fn idkit_cuid_extract_timestamptz_utc(val: String) -> pgrx::TimestampWithTimeZone {
+    #[allow(deprecated)]
+    if !cuid::is_cuid(&val) {
+        pgrx::error!("value provided is not a valid CUID");
+    }
+
+    // Get the base64 epoch milliseconds
+    let epoch_millis = base36::decode(&val[1..9])
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{e:?}")))
+        .or_pgrx_error("failed to base64 decode cuid timestamp");
+    let epoch_millis_len = epoch_millis.len();
+
+    if epoch_millis_len > 8 {
+        pgrx::error!("unexpected length of bytes [{}]", epoch_millis.len());
+    };
+
+    // Copy in bytes from epoch conversion, copy to i64
+    let mut be_bytes = [0; 8];
+    be_bytes[8 - epoch_millis_len..].copy_from_slice(&epoch_millis);
+    let millis_i64 = i64::from_be_bytes(be_bytes);
+
+    // Convert to a UTC timestamp
+    let now = NaiveDateTime::from_timestamp_millis(millis_i64)
+        .or_pgrx_error("failed to parse timestamp from millis")
+        .and_utc();
+
+    pgrx::TimestampWithTimeZone::with_timezone(
+        now.year(),
+        now.month()
+            .try_into()
+            .or_pgrx_error("failed to convert months"),
+        now.day().try_into().or_pgrx_error("failed to convert days"),
+        now.hour()
+            .try_into()
+            .or_pgrx_error("failed to convert hours"),
+        now.minute()
+            .try_into()
+            .or_pgrx_error("failed to convert minutes"),
+        now.second()
+            .try_into()
+            .or_pgrx_error("failed to convert seconds"),
+        "utc",
+    )
+    .or_pgrx_error("failed to convert timestamp")
+}
+
 //////////
 // Test //
 //////////
@@ -23,12 +83,29 @@ fn idkit_cuid_generate_text() -> String {
 #[cfg(any(test, feature = "pg_test"))]
 #[pg_schema]
 mod tests {
+    use chrono::{DateTime, Utc};
     use pgrx::*;
+
+    use crate::cuid::{idkit_cuid_extract_timestamptz_utc, idkit_cuid_generate};
 
     /// Basic length test
     #[pg_test]
     fn test_cuid_len() {
-        let generated = crate::cuid::idkit_cuid_generate();
+        let generated = idkit_cuid_generate();
         assert_eq!(generated.len(), 25);
+    }
+
+    /// Basic test of timestamp instantly generated and verified
+    #[pg_test]
+    fn test_cuid_extract_timestamp_utc() {
+        let cuid = idkit_cuid_generate();
+        let timestamp = idkit_cuid_extract_timestamptz_utc(cuid.clone());
+        let parsed: DateTime<Utc> = DateTime::parse_from_rfc3339(&timestamp.to_iso_string())
+            .expect("extracted timestamp as ISO string parsed to UTC DateTime")
+            .into();
+        assert!(
+            Utc::now().signed_duration_since(parsed).num_seconds() < 3,
+            "extracted, printed & re-parsed cuid timestamp is from recent past (within 3s)"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,15 @@
-mod uuid_v6;
-mod uuid_v7;
-mod nanoid;
-mod ksuid;
-mod ulid;
-mod timeflake;
-mod pushid;
-mod xid;
+mod common;
+
 mod cuid;
 mod cuid2;
+mod ksuid;
+mod nanoid;
+mod pushid;
+mod timeflake;
+mod ulid;
+mod uuid_v6;
+mod uuid_v7;
+mod xid;
 
 use pgrx::pg_module_magic;
 


### PR DESCRIPTION
Some ID generation functions have timestamps embedded in them, and being able to extract the timestamp is a useful feature. Timestamps extracted from IDs can be used in logic checks, as virtual/generated columns and have many other use cases.

This commit adds functions for extracting timestamps to the IDs that support them (i.e. IDs that have a timestamp embedded somehow).