### PR TITLE
chore(ci): disable incremental builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,39 +22,16 @@ jobs:
         CARGO_TARGET_DIR: /usr/local/build/target
         SCCACHE_DIR: /usr/local/sccache
         CARGO_BUILD_RUSTC_WRAPPER: /usr/local/cargo/bin/sccache
+        CARGO_INCREMENTAL: "0"
+        CARGO_PROFILE: "ci"
 
     steps:
       # Checkout the repo
       - uses: actions/checkout@v3
 
-      ##############
-      # Code Tests #
-      ##############
-
-      - name: Add idkit to group
-        run: |
-          chgrp -R idkit $HOME &&
-          chgrp -R idkit /__w/pg_idkit &&
-          chmod g+w -R /__w/pg_idkit
-
-      # Run cargo build
-      - name: Run cargo test
-        run: |
-          su idkit -c "cargo build"
-
-      # Run cargo check
-      - name: Run cargo check
-        run: |
-          su idkit -c "cargo check"
-
-      # Run cargo test
-      - name: Run cargo test
-        run: |
-          su idkit -c "cargo test"
-
-      ####################
-      # Post-run Caching #
-      ####################
+      #########
+      # Cache #
+      #########
 
       - name: Cache CARGO_HOME
         uses: actions/cache@v2
@@ -79,3 +56,28 @@ jobs:
           path: |
             /usr/local/sccache
           key: pg_idkit-tests-sccache-${{ matrix.rust_container_version }}-cargo-${{ runner.os }}
+
+      ###############
+      # Build/Tests #
+      ###############
+
+      - name: Add idkit to group
+        run: |
+          chgrp -R idkit $HOME &&
+          chgrp -R idkit /__w/pg_idkit &&
+          chmod g+w -R /__w/pg_idkit
+
+      # Run cargo build
+      - name: Run cargo test
+        run: |
+          su idkit -c "cargo build"
+
+      # Run cargo check
+      - name: Run cargo check
+        run: |
+          su idkit -c "cargo check"
+
+      # Run cargo test
+      - name: Run cargo test
+        run: |
+          su idkit -c "cargo test"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,7 @@ panic = "unwind"
 opt-level = 3
 lto = "fat"
 codegen-units = 1
+
+[profile.ci]
+inherits = "test"
+incremental = false

--- a/Justfile
+++ b/Justfile
@@ -1,9 +1,16 @@
-cargo := env_var_or_default("CARGO", "cargo")
-cargo_get := env_var_or_default("CARGO_GET", "cargo-get")
-cargo_watch := env_var_or_default("CARGO_WATCH", "cargo-watch")
 docker := env_var_or_default("DOCKER", "docker")
 git := env_var_or_default("GIT", "git")
 just := env_var_or_default("JUST", just_executable())
+
+cargo := env_var_or_default("CARGO", "cargo")
+cargo_get := env_var_or_default("CARGO_GET", "cargo-get")
+cargo_watch := env_var_or_default("CARGO_WATCH", "cargo-watch")
+cargo_profile := env_var_or_default("CARGO_PROFILE", "")
+cargo_profile_arg := if cargo_profile != "" {
+  "--profile " + cargo_profile
+} else {
+  ""
+}
 
 changelog_path := "CHANGELOG"
 
@@ -57,7 +64,7 @@ changelog:
     {{git}} cliff --unreleased --tag=$(VERSION) --prepend=$(CHANGELOG_FILE_PATH)
 
 build:
-    {{cargo}} build
+    {{cargo}} build {{cargo_profile_arg}}
 
 build-watch: _check-tool-cargo _check-tool-cargo-watch
     {{cargo_watch}} -x "build $(CARGO_BUILD_FLAGS)" --watch src
@@ -72,7 +79,7 @@ package:
     {{cargo}} pgrx package --pg-config {{pkg_pg_config_path}}
 
 test:
-    {{cargo}} test
+    {{cargo}} test {{cargo_profile_arg}}
     {{cargo}} pgrx test
 
 ##########

--- a/infra/docker/ci.Dockerfile
+++ b/infra/docker/ci.Dockerfile
@@ -4,6 +4,8 @@ FROM rust:1.73.0-slim-bullseye@sha256:9f7ad33ce267070d8982f4503ec83fd0d7cd19c7e3
 ENV CARGO_HOME=/usr/local/cargo
 ENV CARGO_TARGET_DIR=/usr/local/build/target
 ENV SCCACHE_DIR=/usr/local/sccache
+# Disable cargo incremental builds since sccache can't support them
+ENV CARGO_INCREMENTAL=0
 
 # Install deps
 RUN apt update && apt install -y libssl-dev git openssh-client pkg-config curl ca-certificates gnupg wget


### PR DESCRIPTION
Since builds in CI use sccache, we should be able to disable incremental builds since they actually influence whether sccache can do it's work (https://github.com/mozilla/sccache#known-caveats)

This commit creates a "ci" profile and disables incremental builds in cargo