### PR TITLE
feat(infra): add RPM package

### DIFF
--- a/.github/workflows/rpm.yaml
+++ b/.github/workflows/rpm.yaml
@@ -1,0 +1,60 @@
+name: rpm
+
+on:
+  push:
+    tags:
+      - v[0-9]+\.[0-9]+\.[0-9]+
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        config:
+          - gh:
+              runner: ubuntu-latest
+            rpm:
+              arch: x86_64
+            pgrx:
+              version: pg15
+    runs-on: ${{ matrix.config.gh.runner }}
+    env:
+      CARGO_PROFILE: "ci"
+      PGRX_PG_VERSION: ${{ matrix.config.pgrx.version }}
+      RPM_ARCH: ${{ matrix.config.rpm.arch }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Cache default PGRX_HOME
+        uses: actions/cache@v2
+        continue-on-error: false
+        with:
+          path: |
+            /home/runner/.pgrx
+          key: pg_idkit-pkg-rpm-pgrx-${{ matrix.config.rpm.arch }}-${{ runner.os }}
+
+      - name: Install Rust deps
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-binstall,cargo-get,just,cargo-generate-rpm,cargo-pgrx@0.11.0
+
+      - name: Initialize cargo-pgrx
+        run: |
+          [[ -d /home/runner/.pgrx ]] || cargo pgrx init
+
+      - name: Build RPM
+        run: just package build-rpm
+
+      - name: Get RPM output path
+        id: rpm-output
+        run: |
+          echo path=$(just print-rpm-output-path) >> $GITHUB_OUTPUT
+          echo filename=$(just print-rpm-output-file-name) >> $GITHUB_OUTPUT
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.rpm-output.outputs.filename }}
+          path: ${{ steps.rpm-output.outputs.path }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "pg_idkit"
 version = "0.1.0"
 edition = "2021"
 authors = ["Victor Adossi <vados@vadosware.io>"]
+license = "MIT"
 rust-version = "1.73.0"
 description = """
 A Postgres extension for generating UUIDs
@@ -57,3 +58,51 @@ codegen-units = 1
 [profile.ci]
 inherits = "test"
 incremental = false
+
+[package.metadata.generate-rpm]
+assets = []
+
+[package.metadata.generate-rpm.variants.pg11]
+assets = [
+  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/lib/postgresql/pg_idkit.so", dest = "/usr/lib64/pgsql/pg_idkit.so", mode = "755" },
+  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.1.0.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.1.0.sql", mode = "755" },
+  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit.control", dest = "/usr/share/pgsql/extension/pg_idkit.control", mode = "755" },
+]
+requires = { postgresql-server = "> 11", glibc = "*" }
+release = "pg11"
+
+[package.metadata.generate-rpm.variants.pg12]
+assets = [
+  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/lib/postgresql/pg_idkit.so", dest = "/usr/lib64/pgsql/pg_idkit.so", mode = "755" },
+  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.1.0.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.1.0.sql", mode = "755" },
+  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit.control", dest = "/usr/share/pgsql/extension/pg_idkit.control", mode = "755" },
+]
+requires = { postgresql-server = "> 12", glibc = "*" }
+release = "pg12"
+
+[package.metadata.generate-rpm.variants.pg13]
+assets = [
+  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/lib/postgresql/pg_idkit.so", dest = "/usr/lib64/pgsql/pg_idkit.so", mode = "755" },
+  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.1.0.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.1.0.sql", mode = "755" },
+  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit.control", dest = "/usr/share/pgsql/extension/pg_idkit.control", mode = "755" },
+]
+requires = { postgresql-server = "> 13", glibc = "*" }
+release = "pg13"
+
+[package.metadata.generate-rpm.variants.pg14]
+assets = [
+  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/lib/postgresql/pg_idkit.so", dest = "/usr/lib64/pgsql/pg_idkit.so", mode = "755" },
+  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.1.0.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.1.0.sql", mode = "755" },
+  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit.control", dest = "/usr/share/pgsql/extension/pg_idkit.control", mode = "755" },
+]
+requires = { postgresql-server = "> 14", glibc = "*" }
+release = "pg14"
+
+[package.metadata.generate-rpm.variants.pg15]
+assets = [
+  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/lib/postgresql/pg_idkit.so", dest = "/usr/lib64/pgsql/pg_idkit.so", mode = "755" },
+  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.1.0.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.1.0.sql", mode = "755" },
+  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit.control", dest = "/usr/share/pgsql/extension/pg_idkit.control", mode = "755" },
+]
+requires = { postgresql-server = "> 15", glibc = "*" }
+release = "pg15"


### PR DESCRIPTION
While pg_idkit is not limited to linux distributions that support RPMs, given that some users have requested an RPM package be produced for pg_idkit, and there exists easy integration for publishing RPMs (thakns to `cargo-generate-rpm`), it is easy to add some support for RPMs

This commit adds an RPM package that is produced upon every major release tag, utilizing cargo-generate-rpm.

While the pg_idkit does not currently go as far as to register the RPM with any official entity, RPM releases will be made available vai GitHub releases.

Resolves #29 