### PR TITLE
refactor(docs): rework README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,18 @@
-# `pg_idkit` - a tool kit for generating IDs in postgres
+<h1 align="center">
+  🐘 🪪 `pg_idkit`
+</h1>
+
+```
+postgres=# CREATE EXTENSION pg_idkit;
+CREATE EXTENSION
+
+postgres=# SELECT idkit_uuidv7_generate();
+        idkit_uuidv7_generate
+--------------------------------------
+ 018c106f-9304-79bb-b5be-4483b92b036c
+```
+
+## Description
 
 `pg_idkit` is a [Postgres][postgres] extension for generating IDs. It aims to be have just about every ID you'd normally think of using:
 
@@ -29,7 +43,98 @@ Here are some you may or may not have heard of:
 - [`geckoboard/pgulid`](https://github.com/geckoboard/pgulid)
 - [this gist by `fabiolimace` for generating UUIDv6](https://gist.github.com/fabiolimace/515a0440e3e40efeb234e12644a6a346)
 
+## Quickstart
+
+You can try out `pg_idkit` incredibly quickly by using `docker`, and a previously [released package of `pg_idkit`][released-packages]:
+
+```console
+docker run \
+    --rm \
+    -e POSTGRES_PASSWORD=replace_this \
+    -p 5432 \
+    --name pg_idkit \
+    ghcr.io/vadosware/pg_idkit:0.1.0-pg15.5-alpine3.18-amd64
+```
+
+> [!WARNING]
+> Currently only amd64 (x86_64) images are present/supported (See [`pg_idkit` packages][released-packages]).
+>
+> Work to support more platforms is described in [issue #30](https://github.com/VADOSWARE/pg_idkit/issues/30)
+
+Once the postgres server is running, open another shell and connect to the dockerized Postgres instance running on port `5432`:
+
+```console
+➜ docker exec -it pg_idkit psql -U postgres
+psql (15.5)
+Type "help" for help.
+
+postgres=# CREATE EXTENSION pg_idkit;
+CREATE EXTENSION
+
+postgres=# SELECT idkit_uuidv7_generate();
+        idkit_uuidv7_generate
+--------------------------------------
+ 018c106f-9304-79bb-b5be-4483b92b036c
+(1 row)
+```
+
 ## Installing `pg_idkit`
+
+<details>
+<summary>📃 From Source</summary>
+
+### Source install
+
+To build `pg_idkit` from source, clone this repository and run the following:
+
+```console
+cargo install cargo-get cargo-pgrx just
+just package
+```
+
+After running these commands you should see the following directory structure in `target/release/pg_idkit-pg15`:
+
+```
+target/release/pg_idkit-pg15
+├── home
+│   └── <user>
+│       └── .pgrx
+│           └── 15.5
+│               └── pgrx-install
+│                   ├── lib
+│                   │   └── postgresql
+│                   │       └── pg_idkit.so
+│                   └── share
+│                       └── postgresql
+│                           └── extension
+│                               ├── pg_idkit--0.1.0.sql
+│                               └── pg_idkit.control
+└── usr
+    ├── lib
+    │   └── postgresql
+    │       └── pg_idkit.so
+    └── share
+        └── postgresql
+            └── extension
+                └── pg_idkit.control
+
+24 directories, 8 files
+```
+
+As the installation of the extension into a specific version of postgres uses your local installation of pgrx-managed Postgres by default (normally at `$HOME/.pgrx`), `cargo pgrx package` reproduces the directory structure in `target/release`. You can safely ignore the shorter `usr/lib`/`user/share` tree.
+
+In the example above, the [files you need for a Postgres extension][pg-ext-files] are:
+
+- `target/release/home/<user>/.pgrx/15.5/pgrx-install/lib/postgresql/pg_idkit.so`
+- `target/release/home/<user>/.pgrx/15.5/pgrx-install/share/postgresql/extension/pg_idkit--0.1.0.sql`
+- `target/release/home/<user>/.pgrx/15.5/pgrx-install/share/postgresql/extension/pg_idkit.control`
+
+Install these files in the relevant folders for your Postgres installation -- note that exactly where these files should go can can differ across linux distributions and containerized environments.
+
+</details>
+
+<details>
+<summary>💽 From Binary</summary>
 
 ### Binary install
 
@@ -41,6 +146,22 @@ Assuming you have downloaded the `pg_idkit-vX.X.X.so` file to `/etc/postgresql/e
 ```
 shared_preload_libraries = '/etc/postgresql/extensions/pg_idkit-vX.X.X.so'
 ```
+
+Once your postgres instance is started up, you should be able to `CREATE EXTENSION`:
+
+```
+postgres=# CREATE EXTENSION pg_idkit;
+CREATE EXTENSION
+postgres=# SELECT idkit_uuidv7_generate();
+        idkit_uuidv7_generate
+--------------------------------------
+ 018c106f-9304-79bb-b5be-4483b92b036c
+```
+
+</details>
+
+<details>
+<summary>🐳 Dockerfile</summary>
 
 ### Dockerfile
 
@@ -72,128 +193,52 @@ postgres=# SELECT idkit_uuidv7_generate();
 ```
 
 > [!WARNING]
-> Currently only amd64 (x86_64) images are present/supported (See [`pg_idkit` packages](https://github.com/VADOSWARE/pg_idkit/pkgs/container/pg_idkit)).
+> Currently only amd64 (x86_64) images are present/supported (See [`pg_idkit` packages][released-packages]).
 >
 > Work to support more platforms is described in [issue #30](https://github.com/VADOSWARE/pg_idkit/issues/30)
 
 [docker-postgres]: https://hub.docker.com/_/postgres
 
-## Local Development
+</details>
 
-Here's how to get started working on `pg_idkit` locally.
+<details>
+<summary>📦 Debian (RPM)</summary>
 
-### Prerequisites
+### RPM install
 
-To work on `pg_idkit`, you'll need the following:
+RPMs are produced upon [every official release](/releases) of `pg_idkit`.
 
-- [Rust][rust] toolchain (via [`rustup`][rustup])
-- [`cargo-pgrx`][cargo-pgrx] (see below for more details)
-- [`just`][just] (see below for more details)
-- (optional) [`git-crypt`][git-crypt] (for working with secrets)
-- (optional) [direnv][direnv]
-- (optional) [Docker][docker]
-- (optional) [`cargo-watch`][cargo-watch]
+Grab a released version of the RPM (or build one yourself by running `just build-rpm` after [setting up local development][guide-localdev]).
 
-#### `just`
-
-This project uses a task runner similar to `make` called [`just`][just]. You can install it easily with `cargo`:
-
-```console
-cargo install --locked just
-```
-
-#### `cargo-pgrx`
-
-Installing
-
-```console
-cargo install --locked cargo-pgrx
-cargo pgrx init
-```
-
-## Building the project
-
-To build the project:
-
-```console
-just build
-```
-
-To run the build continuously for quicker local development (assuming you have `cargo-watch` installed):
-
-```console
-just build-watch
-```
-
-### `pgrx` workflow
-
-Note that you can use the `pgrx`-documented development flow as well (using `cargo pgrx`) as well, for example:
-
-```console
-cargo pgrx run pg15
-```
-
-## Run tests
-
-To run the tests:
-
-```console
-just test
-```
-
-To run tests continuously for quicker local development (requires `cargo-watch`):
-
-```console
-just build-test-watch
-```
-
-## Starting a local Postgres instance with `pg_idkit` installed
-
-Assuming you have Docker installed, to start a local Postgres instance first you must build a `postgres` docker image with `pg_idkit`:
-
-```console
-just image
-```
-
-Then start the container:
-
-```console
-just db-local
-```
-
-You may attach to the local DB with `psql` and execute commands:
-
-```console
-just db-local-psql
-```
-
-# Continuous Integration
-
-To push up images that are used from continuous integration:
-
-1. Get a personal access token from Github
-2. Ensuring `DOCKER_LOGIN` is set (see instructions above)
-3. Perform a login
-   1. Manually via `echo $GH_PAT | docker login ghcr.io -u <username> --password-stdin`
-   2. Automatically, via `just docker-login` which will use the `git-crypt` protected credentials (you must have run `git-crypt` unlock first)
-4. Observe the docker login credentials generated in this local repo directory (`secrets/docker/config.json`)
-5. Run `just build-ci-image push-ci-image`
-
-# Packaging
-
-## Setting up for Docker usage
-
-Assuming you are using something like [`direnv`][direnv], use the following `.envrc` file:
+For example, with an RPM named `pg_idkit-0.1.0-pg15.x86_64.rpm`, you should be able to run:
 
 ```
-# Use local docker auth file
-export DOCKER_CONFIG=$(realpath secrets/docker)
+dnf install pg_idkit-0.1.0-pg15.x86_64.rpm
 ```
 
-**NOTE**, that is *not* a `.env` file, it is a `.envrc` file, with separate semantics
+</details>
+
+## Setting up for local development
+
+Interested in contributing on the project? Set up your local development environment w/ [`docs/local-development.md`][guide-localdev].
+
+## Contributing
+
+Contributions are welcome!
+
+If you find a bug or an impovement that should be included in `pg_idkit`, [create an issue](https://github.com/vadosware/pg_idkit/issues).
+
+If you'd like to contribute code, get started by:
+
+1. Reading the [local development guide][guide-localdev]
+2. Creating an issue (if necessary) to explain the new feature/bugfix/etc
+3. Forking this repository
+4. Creating a feature/bugfix/etc branch  (we expect [conventional commits][conventional-commits], i.e. `feat: new awesome feature`)
+5. Opening a Pull Request to this repository
 
 [a-chilton]: https://github.com/chilts
 [a-feerasta]: https://github.com/alizain
+[cargo-get]: https://crates.io/crates/cargo-get
 [cargo-pgrx]: https://crates.io/crates/cargo-pgrx
 [cargo-watch]: https://github.com/passcod/cargo-watch
 [cuid2]: https://github.com/paralleldrive/cuid2
@@ -216,6 +261,7 @@ export DOCKER_CONFIG=$(realpath secrets/docker)
 [oryx-pro]: https://system76.com/laptops/oryx
 [p-pearcy]: https://github.com/ppearcy/elasticflake
 [pg-docs-operator-classes]: https://www.postgresql.org/docs/current/indexes-opclass.html
+[pg-ext-files]: https://www.postgresql.org/docs/current/extend-extensions.html#EXTEND-EXTENSIONS-FILES
 [pgstattuple]: https://www.postgresql.org/docs/current/pgstattuple.html
 [postgres]: https://postgresql.org
 [pushid]: https://firebase.googleblog.com/2015/02/the-2120-ways-to-ensure-unique_68.html
@@ -238,3 +284,5 @@ export DOCKER_CONFIG=$(realpath secrets/docker)
 [wiki-mac-address]: https://en.wikipedia.org/wiki/MAC_address
 [wiki-uuid]: https://en.wikipedia.org/wiki/Universally_unique_identifier
 [xid]: https://github.com/rs/xid
+[released-packages]: https://github.com/VADOSWARE/pg_idkit/pkgs/container/pg_idkit
+[guide-localdev]: ./docs/local-development.md

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,11 @@
+# Continuous Integration
+
+To push up images that are used from continuous integration:
+
+1. Get a personal access token from Github
+2. Ensuring `DOCKER_LOGIN` is set (see instructions above)
+3. Perform a login
+   1. Manually via `echo $GH_PAT | docker login ghcr.io -u <username> --password-stdin`
+   2. Automatically, via `just docker-login` which will use the `git-crypt` protected credentials (you must have run `git-crypt` unlock first)
+4. Observe the docker login credentials generated in this local repo directory (`secrets/docker/config.json`)
+5. Run `just build-ci-image push-ci-image`

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,0 +1,91 @@
+## Local Development
+
+Here's how to get started working on `pg_idkit` locally.
+
+### Prerequisites
+
+To work on `pg_idkit`, you'll need the following:
+
+- [Rust][rust] toolchain (via [`rustup`][rustup])
+- [`cargo-pgrx`][cargo-pgrx] (see below for more details)
+- [`cargo-get`][cargo-get]
+- [`just`][just] (see below for more details)
+- (optional) [`git-crypt`][git-crypt] (for working with secrets)
+- (optional) [direnv][direnv]
+- (optional) [Docker][docker]
+- (optional) [`cargo-watch`][cargo-watch]
+
+#### `just`
+
+This project uses a task runner similar to `make` called [`just`][just]. You can install it easily with `cargo`:
+
+```console
+cargo install --locked just
+```
+
+#### `cargo-pgrx`
+
+The PGRX project is the magic behind this extension, exposing an easy-to-program interface in Rust for Postgres extensions.
+
+To install it:
+
+```console
+cargo install --locked cargo-pgrx@0.11.0
+cargo pgrx init
+```
+
+## Building the project
+
+To build the project:
+
+```console
+just build
+```
+
+To run the build continuously for quicker local development (assuming you have `cargo-watch` installed):
+
+```console
+just build-watch
+```
+
+### `pgrx` workflow
+
+Note that you can use the `pgrx`-documented development flow as well (using `cargo pgrx`) as well, for example:
+
+```console
+cargo pgrx run pg15
+```
+
+## Run tests
+
+To run the tests:
+
+```console
+just test
+```
+
+To run tests continuously for quicker local development (requires `cargo-watch`):
+
+```console
+just build-test-watch
+```
+
+## Starting a local Postgres instance with `pg_idkit` installed
+
+Assuming you have Docker installed, to start a local Postgres instance first you must build a `postgres` docker image with `pg_idkit`:
+
+```console
+just image
+```
+
+Then start the container:
+
+```console
+just db-local
+```
+
+You may attach to the local DB with `psql` and execute commands:
+
+```console
+just db-local-psql
+```

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,0 +1,12 @@
+# Packaging
+
+## Setting up for Docker usage
+
+Assuming you are using something like [`direnv`][direnv], use the following `.envrc` file:
+
+```
+# Use local docker auth file
+export DOCKER_CONFIG=$(realpath secrets/docker)
+```
+
+**NOTE**, that is *not* a `.env` file, it is a `.envrc` file, with separate semantics


### PR DESCRIPTION
The documentation for pg_idkit isn't very tight/easy to use, despite the ease of using `pgrx` and associated tooling/the extension itself.

This commit improves the README by making it terser, hiding information that is unnecssary, and moving some contributor-specific details and other niche information to a `docs` folder.

- [x] move developer specific things (ex. local docker configuration, direnv, etc) to docs/local-dev.md or some similar file
- [x] Remove all non-working links
- [x] Simplify install instructions, possibly similar to [pg_jsonschema](https://github.com/supabase/pg_jsonschema)

Resolves #14 