### PR TITLE
ops: add automated release workflow

### DIFF
--- a/.github/workflows/prep-release.yaml
+++ b/.github/workflows/prep-release.yaml
@@ -1,0 +1,58 @@
+name: release-pr
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to release (ex. `v0.1.0`)
+        required: false
+        type: string
+
+jobs:
+  make-release-pr:
+    permissions:
+      id-token: write
+      pull-requests: write
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      # Set up caching
+      - uses: Swatinem/rust-cache@v2
+      - name: Cache default PGRX_HOME
+        uses: actions/cache@v2
+        continue-on-error: false
+        with:
+          path: |
+            /home/runner/.pgrx
+          key: pg_idkit-pkg-rpm-pgrx-${{ matrix.config.rpm.arch }}-${{ runner.os }}
+
+      # Install deps
+      - uses: chainguard-dev/actions/setup-gitsign@main
+      - name: Install cargo-release
+        uses: taiki-e/install-action@v1
+        with:
+          tool: cargo-release,just,cargo-get,cargo-pgrx,git-cliff
+
+      # Initialize PGRX
+      - name: Initialize cargo-pgrx
+        run: |
+          [[ -d /home/runner/.pgrx ]] || cargo pgrx init
+
+      # Prep the project
+      - name: Determine version
+        id: determine-version
+        env:
+          VERSION: ${{inputs.version}}
+        run: |
+          echo value=$(just print-version) >> $GITHUB_OUTPUT
+      - name: Generate changelog
+        run: |
+          just changelog
+
+      # Create PR for release
+      - uses: cargo-bins/release-pr@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # TODO: We should configure the PR text
+          version: ${{ steps.determine-version.outputs.value }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1169,9 +1169,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "option-ext"
@@ -2748,9 +2748,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.25"
+version = "0.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e87b8dfbe3baffbe687eef2e164e32286eff31a5ee16463ce03d991643ec94"
+checksum = "b67b5f0a4e7a27a64c651977932b9dc5667ca7fc31ac44b03ed37a0cf42fdfff"
 dependencies = [
  "memchr",
 ]

--- a/Justfile
+++ b/Justfile
@@ -22,7 +22,7 @@ cargo_features_arg := if cargo_features != "" {
   ""
 }
 
-changelog_path := "CHANGELOG"
+changelog_file_path := absolute_path(justfile_directory() / "CHANGELOG")
 
 pkg_pg_version := env_var_or_default("PKG_PG_VERSION", "15.5")
 pkg_pg_config_path := env_var_or_default("PKG_PG_CONFIG_PATH", "~/.pgrx/" + pkg_pg_version + "/pgrx-install/bin/pg_config")
@@ -63,8 +63,8 @@ _check-installed-version tool msg:
 # Build #
 #########
 
-version := `cargo get package.version`
-revision := `git rev-parse --short HEAD`
+version := env_var_or_default("VERSION", `cargo get package.version`)
+revision := env_var_or_default("REVISION", `git rev-parse --short HEAD`)
 
 # NOTE: we can't use this as the official version getter until
 # see: https://github.com/nicolaiunrein/cargo-get/issues/14
@@ -83,7 +83,7 @@ print-revision:
     echo -n `{{just}} get-revision`
 
 changelog:
-    {{git}} cliff --unreleased --tag=$(VERSION) --prepend=$(CHANGELOG_FILE_PATH)
+    {{git}} cliff --unreleased --tag={{version}} --prepend={{changelog_file_path}}
 
 lint:
     {{cargo}} clippy {{cargo_features_arg}} {{cargo_profile_arg}} --all-targets

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ postgres=# SELECT idkit_uuidv7_generate();
 
 ## Description
 
-`pg_idkit` is a [Postgres][postgres] extension for generating IDs. It aims to be have just about every ID you'd normally think of using:
+`pg_idkit` is a [Postgres][postgres] extension for generating many popular types of identifiers:
 
 | Methodology               | Function                                    | Crate                                | Description                                              |
 |---------------------------|---------------------------------------------|--------------------------------------|----------------------------------------------------------|


### PR DESCRIPTION
The release workflow should be automated, and this PR does that, facilitating a flow like the following:

- Dispatching the workflow to prep a release
- Reviewing of the release PR
- Merging the release PR once the release is ready

This commit adds automation to create release PRs upon pushes to branches that match a certain format.

We're relying heavily on:

- https://github.com/crate-ci/cargo-release
- https://github.com/cargo-bins/release-pr