### PR TITLE
release: pg_idkit v0.2.1

### DIFF
--- a/.github/workflows/build-and-test-gnu/action.yaml
+++ b/.github/workflows/build-and-test-gnu/action.yaml
@@ -125,7 +125,7 @@ runs:
         PGRX_PKG_PATH_PREFIX: ${{ inputs.cargo-target-dir }}
         PKG_PG_VERSION: ${{ inputs.pg-version }}
         SCCACHE_DIR: ${{ inputs.sccache-dir }}
-        USER: ${{ inputs.user }}
+        DOCKER_BUILD_USER: ${{ inputs.user }}
       run: |
         su idkit -c "cargo install --force cargo-get cargo-edit"
 
@@ -146,7 +146,7 @@ runs:
         PGRX_PKG_PATH_PREFIX: ${{ inputs.cargo-target-dir }}
         PKG_PG_VERSION: ${{ inputs.pg-version }}
         SCCACHE_DIR: ${{ inputs.sccache-dir }}
-        USER: ${{ inputs.user }}
+        DOCKER_BUILD_USER: ${{ inputs.user }}
       run: |
         su idkit -c "just pgrx-init"
 
@@ -163,7 +163,7 @@ runs:
         PGRX_PKG_PATH_PREFIX: ${{ inputs.cargo-target-dir }}
         PKG_PG_VERSION: ${{ inputs.pg-version }}
         SCCACHE_DIR: ${{ inputs.sccache-dir }}
-        USER: ${{ inputs.user }}
+        DOCKER_BUILD_USER: ${{ inputs.user }}
       run: |
         su idkit -c "cargo check"
 
@@ -180,7 +180,7 @@ runs:
         PGRX_PKG_PATH_PREFIX: ${{ inputs.cargo-target-dir }}
         PKG_PG_VERSION: ${{ inputs.pg-version }}
         SCCACHE_DIR: ${{ inputs.sccache-dir }}
-        USER: ${{ inputs.user }}
+        DOCKER_BUILD_USER: ${{ inputs.user }}
       run: |
         su idkit -c "cargo build"
 
@@ -196,7 +196,7 @@ runs:
         PGRX_PG_VERSION: ${{ inputs.pgrx-pg-version }}
         PKG_PG_VERSION: ${{ inputs.pg-version }}
         SCCACHE_DIR: ${{ inputs.sccache-dir }}
-        USER: ${{ inputs.user }}
+        DOCKER_BUILD_USER: ${{ inputs.user }}
       run: |
         su idkit -c "cargo test"
 
@@ -219,7 +219,7 @@ runs:
         PKG_PG_VERSION: ${{ inputs.pg-version }}
         PKG_TARBALL_SUFFIX: ${{ inputs.artifact-tarball-suffix }}
         SCCACHE_DIR: ${{ inputs.sccache-dir }}
-        USER: ${{ inputs.user }}
+        DOCKER_BUILD_USER: ${{ inputs.user }}
       run: |
         su idkit -c "just package"
 

--- a/.github/workflows/build-rpm/action.yaml
+++ b/.github/workflows/build-rpm/action.yaml
@@ -29,6 +29,9 @@ inputs:
     default: 16.1
     decription: |
       Postgres version (ex. '15.5, '16.1')
+  user:
+    type: string
+    default: runner
 outputs: {}
 runs:
   using: "composite"
@@ -61,6 +64,7 @@ runs:
     - name: Build RPM
       shell: bash
       env:
+        DOCKER_BUILD_USER: ${{ inputs.user }}
         PGRX_PG_VERSION: ${{ inputs.pgrx-pg-version }}
         PKG_PG_VERSION: ${{ inputs.pg-version }}
       run: just package build-rpm
@@ -69,6 +73,7 @@ runs:
       id: rpm-output
       shell: bash
       env:
+        DOCKER_BUILD_USER: ${{ inputs.user }}
         PGRX_PG_VERSION: ${{ inputs.pgrx-pg-version }}
         PKG_PG_VERSION: ${{ inputs.pg-version }}
       run: |

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -46,18 +46,22 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Build container image (prerelease)
+        if: ${{ startsWith(github.ref, 'refs/heads/prep-release') }}
+        run: just build-image push-image
+        env:
+          CONTAINER_IMAGE_ARCH: ${{ matrix.config.container.arch }}
+          PGRX_PG_VERSION: ${{ matrix.config.container.pg_version }}
+          POSTGRES_IMAGE_VERSION: ${{ matrix.config.container.pg_version }}
+          POSTGRES_OS_IMAGE_VERSION: ${{ matrix.config.container.os_version }}
+          PGIDKIT_IMAGE_TAG_SUFFIX: "-prerelease"
+
       - name: Build container image
-        run: just build-image
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        run: just build-image push-image
         env:
           CONTAINER_IMAGE_ARCH: ${{ matrix.config.container.arch }}
           PGRX_PG_VERSION: ${{ matrix.config.container.pg_version }}
           POSTGRES_IMAGE_VERSION: ${{ matrix.config.container.pg_version }}
           POSTGRES_OS_IMAGE_VERSION: ${{ matrix.config.container.os_version }}
 
-      - name: Push pre-release image
-        if: ${{ startsWith(github.ref, 'refs/heads/prep-release') }}
-        run: just push-image-preprelease
-
-      - name: Push release image
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        run: just push-image

--- a/.github/workflows/prep-release.yaml
+++ b/.github/workflows/prep-release.yaml
@@ -94,6 +94,10 @@ jobs:
 
             Upon merging, this branch will cause a tag to be placed on the commit in `main`. After the tag has been placed, a build will run that generates artifacts and publishes a release.
 
+            Before this release is ready, here is the checklist:
+              - [ ] Update the examples in `README.md` to use the newest version
+              - [ ] Update `generate-rpm` configuration in `Cargo.toml` version references (ex. `--0.2.0.sql` -> `--0.2.1.sql`)
+
             See CHANGELOG for changes made to this release before it goes out.
           labels: |
             release-pr

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.2.1] - 2023-12-19
+
+### Bug Fixes
+
+- Fix release prep PR title
+- Container generation and workflows
+
 ## [0.2.0] - 2023-12-12
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "pg_idkit"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base36",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg_idkit"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Victor Adossi <vados@vadosware.io>"]
 license = "MIT"
@@ -65,7 +65,7 @@ assets = []
 [package.metadata.generate-rpm.variants.pg11]
 assets = [
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/lib/postgresql/pg_idkit.so", dest = "/usr/lib64/pgsql/pg_idkit.so", mode = "755" },
-  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.2.0.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.2.0.sql", mode = "755" },
+  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.2.1.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.2.1.sql", mode = "755" },
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit.control", dest = "/usr/share/pgsql/extension/pg_idkit.control", mode = "755" },
 ]
 requires = { postgresql-server = "> 11", glibc = "*" }
@@ -74,7 +74,7 @@ release = "pg11"
 [package.metadata.generate-rpm.variants.pg12]
 assets = [
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/lib/postgresql/pg_idkit.so", dest = "/usr/lib64/pgsql/pg_idkit.so", mode = "755" },
-  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.2.0.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.2.0.sql", mode = "755" },
+  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.2.1.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.2.1.sql", mode = "755" },
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit.control", dest = "/usr/share/pgsql/extension/pg_idkit.control", mode = "755" },
 ]
 requires = { postgresql-server = "> 12", glibc = "*" }
@@ -83,7 +83,7 @@ release = "pg12"
 [package.metadata.generate-rpm.variants.pg13]
 assets = [
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/lib/postgresql/pg_idkit.so", dest = "/usr/lib64/pgsql/pg_idkit.so", mode = "755" },
-  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.2.0.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.2.0.sql", mode = "755" },
+  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.2.1.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.2.1.sql", mode = "755" },
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit.control", dest = "/usr/share/pgsql/extension/pg_idkit.control", mode = "755" },
 ]
 requires = { postgresql-server = "> 13", glibc = "*" }
@@ -92,7 +92,7 @@ release = "pg13"
 [package.metadata.generate-rpm.variants.pg14]
 assets = [
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/lib/postgresql/pg_idkit.so", dest = "/usr/lib64/pgsql/pg_idkit.so", mode = "755" },
-  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.2.0.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.2.0.sql", mode = "755" },
+  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.2.1.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.2.1.sql", mode = "755" },
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit.control", dest = "/usr/share/pgsql/extension/pg_idkit.control", mode = "755" },
 ]
 requires = { postgresql-server = "> 14", glibc = "*" }
@@ -101,7 +101,7 @@ release = "pg14"
 [package.metadata.generate-rpm.variants.pg15]
 assets = [
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/lib/postgresql/pg_idkit.so", dest = "/usr/lib64/pgsql/pg_idkit.so", mode = "755" },
-  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.2.0.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.2.0.sql", mode = "755" },
+  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.2.1.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.2.1.sql", mode = "755" },
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit.control", dest = "/usr/share/pgsql/extension/pg_idkit.control", mode = "755" },
 ]
 requires = { postgresql-server = "> 15", glibc = "*" }
@@ -110,7 +110,7 @@ release = "pg15"
 [package.metadata.generate-rpm.variants.pg16]
 assets = [
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/lib/postgresql/pg_idkit.so", dest = "/usr/lib64/pgsql/pg_idkit.so", mode = "755" },
-  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.2.0.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.2.0.sql", mode = "755" },
+  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.2.1.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.2.1.sql", mode = "755" },
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit.control", dest = "/usr/share/pgsql/extension/pg_idkit.control", mode = "755" },
 ]
 requires = { postgresql-server = "> 16", glibc = "*" }

--- a/Justfile
+++ b/Justfile
@@ -140,7 +140,8 @@ pg_os_image_version := env_var_or_default("POSTGRES_OS_IMAGE_VERSION", "alpine3.
 
 pgidkit_image_name := env_var_or_default("PGIDKIT_IMAGE_NAME", "ghcr.io/vadosware/pg_idkit")
 pgidkit_image_tag := env_var_or_default("POSGRES_IMAGE_VERSION", version + "-" + "pg" + pg_image_version + "-" + pg_os_image_version + "-" + container_img_arch)
-pgidkit_image_name_full := env_var_or_default("PGIDKIT_IMAGE_NAME_FULL", pgidkit_image_name + ":" + pgidkit_image_tag)
+pgidkit_image_tag_suffix := env_var_or_default("PGIDKIT_IMAGE_TAG_SUFFIX", "")
+pgidkit_image_name_full := env_var_or_default("PGIDKIT_IMAGE_NAME_FULL", pgidkit_image_name + ":" + pgidkit_image_tag + pgidkit_image_tag_suffix)
 pgidkit_dockerfile_path := env_var_or_default("PGIDKIT_DOCKERFILE_PATH", "infra" / "docker" / pgidkit_image_tag + ".Dockerfile")
 
 docker_password_path := env_var_or_default("DOCKER_PASSWORD_PATH", "secrets/docker/password.secret")
@@ -231,10 +232,6 @@ push-base-pkg-image:
 # Build the docker image for pg_idkit
 build-image:
     {{docker}} build {{docker_platform_arg}} {{docker_progress_arg}} -f {{img_dockerfile_path}} -t {{pgidkit_image_name_full}} --build-arg USER={{docker_build_user}} --build-arg PGIDKIT_REVISION={{revision}} --build-arg PGIDKIT_VERSION={{pgidkit_image_tag}} .
-
-# Push the pre-release docker image for pg_idkit
-push-image-prerelease:
-    {{docker}} push {{pgidkit_image_name_full}}-prerelease
 
 # Push the docker image for pg_idkit
 push-image:


### PR DESCRIPTION
This is a release prep branch for `pg_idkit` release v0.2.1.

Upon merging, this branch will cause a tag to be placed on the commit in `main`. After the tag has been placed, a build will run that generates artifacts and publishes a release.

See CHANGELOG for changes made to this release before it goes out.