### PR TITLE
feat(nanoid): add customizable nanoid generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ postgres=# SELECT idkit_uuidv7_generate();
 |                           | `idkit_uuidv7_generate_uuid()`              |                                      |                                                          |
 |                           | `idkit_uuidv7_extract_timestamptz(TEXT)`    |                                      |                                                          |
 | [nanoid][nanoid]          | `idkit_nanoid_generate()`                   | [`nanoid`][crate-nanoid]             | NanoID, developed by [Andrey Sitnik][github-ai]          |
+| [nanoid][nanoid]          | `idkit_nanoid_custom_generate_text()`       | [`nanoid`][crate-nanoid]             | NanoID with a custom length and alphabet                 |
 | [ksuid][ksuid]            | `idkit_ksuid_generate()`                    | [`svix-ksuid`][crate-svix-ksuid]     | Created by [Segment][segment]                            |
 |                           | `idkit_ksuid_extract_timestamptz(TEXT)`     |                                      |                                                          |
 | [ksuid][ksuid]            | `idkit_ksuidms_generate()`                  | [`svix-ksuid`][crate-svix-ksuid]     | Same as `ksuid` but with millisecond precision           |

--- a/src/nanoid.rs
+++ b/src/nanoid.rs
@@ -1,3 +1,5 @@
+use std::convert::TryFrom;
+
 use nanoid::nanoid;
 use pgrx::*;
 
@@ -11,6 +13,19 @@ fn idkit_nanoid_generate() -> String {
 #[pg_extern]
 fn idkit_nanoid_generate_text() -> String {
     idkit_nanoid_generate()
+}
+
+/// Generate a nanoid, using a configurable alphabet, producing a Postgres text object
+#[pg_extern]
+fn idkit_nanoid_custom_generate_text(len: i64, alphabet: String) -> String {
+    let len = match usize::try_from(std::cmp::max(len, 0)) {
+        Ok(v) => v,
+        Err(e) => {
+            pgrx::error!("invalid length, cannot convert to platform-specific quantity: {e}")
+        }
+    };
+    let alphabet = alphabet.chars().collect::<Vec<char>>();
+    nanoid!(len, &alphabet)
 }
 
 //////////
@@ -27,5 +42,21 @@ mod tests {
     fn test_nanoid_len() {
         let generated = crate::nanoid::idkit_nanoid_generate();
         assert_eq!(generated.len(), 21);
+    }
+
+    #[pg_test]
+    /// Test a custom alphabet
+    fn test_nanoid_custom_alphabet() {
+        let generated = crate::nanoid::idkit_nanoid_custom_generate_text(21, "abc".into());
+        assert_eq!(generated.len(), 21);
+        assert!(generated.chars().all(|c| ('a'..='c').contains(&c)));
+    }
+
+    #[pg_test]
+    /// Test a custom len
+    fn test_nanoid_custom_len() {
+        let generated = crate::nanoid::idkit_nanoid_custom_generate_text(10, "abc".into());
+        assert_eq!(generated.len(), 10);
+        assert!(generated.chars().all(|c| ('a'..='c').contains(&c)));
     }
 }


### PR DESCRIPTION
This commit adds customizable nanoid generation, including length and custom alphabets that can be passed to `nanoid`.

Resolves #60 