### PR TITLE
Allow non-root users to install this extension

### DIFF
--- a/pg_idkit.control
+++ b/pg_idkit.control
@@ -2,4 +2,4 @@ comment = 'multi-tool for generating new/niche universally unique identifiers (e
 default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/pg_idkit'
 relocatable = false
-superuser = false
+superuser = true


### PR DESCRIPTION
Currently, if non-root users try to install the extension `create extension pg_idkit` it fails with `permission denied for language c`.

In order to enable it, we need to change the attribute in the control file.

I fixed the template in `pgrx` some time ago (https://github.com/pgcentralfoundation/pgrx/pull/1056), but, it seems, that you started the development of this extension earlier then I fixed the template.