### PR TITLE
release: pg_idkit v0.2.4

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -22,21 +22,24 @@ jobs:
               runner: ubuntu-22.04
             container:
               arch: amd64
-              pg_version: 15.8
+              pgrx_pg_version: pg15
+              pg_version: "15.8"
               os_version: alpine3.20.3
           - triple: x86_64-unknown-linux-musl
             gh:
               runner: ubuntu-22.04
             container:
               arch: amd64
-              pg_version: 16.4
+              pgrx_pg_version: pg16
+              pg_version: "16.4"
               os_version: alpine3.20.3
           - triple: x86_64-unknown-linux-musl
             gh:
               runner: ubuntu-22.04
             container:
               arch: amd64
-              pg_version: 17.0
+              pgrx_pg_version: pg17
+              pg_version: "17.0"
               os_version: alpine3.20.3
     steps:
       - uses: actions/checkout@v3
@@ -57,7 +60,7 @@ jobs:
         run: just build-image push-image
         env:
           CONTAINER_IMAGE_ARCH: ${{ matrix.config.container.arch }}
-          PGRX_PG_VERSION: ${{ matrix.config.container.pg_version }}
+          PGRX_PG_VERSION: ${{ matrix.config.container.pgrx_pg_version }}
           POSTGRES_IMAGE_VERSION: ${{ matrix.config.container.pg_version }}
           POSTGRES_OS_IMAGE_VERSION: ${{ matrix.config.container.os_version }}
           PGIDKIT_IMAGE_TAG_SUFFIX: "-prerelease"
@@ -67,6 +70,6 @@ jobs:
         run: just build-image push-image
         env:
           CONTAINER_IMAGE_ARCH: ${{ matrix.config.container.arch }}
-          PGRX_PG_VERSION: ${{ matrix.config.container.pg_version }}
+          PGRX_PG_VERSION: ${{ matrix.config.container.pgrx_pg_version }}
           POSTGRES_IMAGE_VERSION: ${{ matrix.config.container.pg_version }}
           POSTGRES_OS_IMAGE_VERSION: ${{ matrix.config.container.os_version }}

--- a/.github/workflows/prep-release.yaml
+++ b/.github/workflows/prep-release.yaml
@@ -95,7 +95,8 @@ jobs:
             Upon merging, this branch will cause a tag to be placed on the commit in `main`. After the tag has been placed, a build will run that generates artifacts and publishes a release.
 
             Before this release is ready, here is the checklist:
-              - [ ] Update the examples in `README.md` to use the newest version
+              - [ ] Update `README.md` to use the newest version of Postgres, if it has changed (ex. `16.2` -> `17.0`)
+              - [ ] Update `README.md` to soon-to-be-released pg_idkit (ex. `pg_idkit-0.2.0` -> `pg_idkit-0.2.1`)
               - [ ] Update `generate-rpm` configuration in `Cargo.toml` version references (ex. `--0.2.0.sql` -> `--0.2.1.sql`)
 
             See CHANGELOG for changes made to this release before it goes out.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,15 +29,15 @@ jobs:
           - pgrx:
               pg-version: pg15
             pg:
-              version: 15.8
+              version: "15.8"
           - pgrx:
               pg-version: pg16
             pg:
-              version: 16.4
+              version: "16.4"
           - pgrx:
               pg-version: pg17
             pg:
-              version: 17.0
+              version: "17.0"
     steps:
       - uses: actions/checkout@v3
 
@@ -59,15 +59,15 @@ jobs:
           - pgrx:
               pg-version: pg15
             pg:
-              version: 15.8
+              version: "15.8"
           - pgrx:
               pg-version: pg16
             pg:
-              version: 16.4
+              version: "16.4"
           - pgrx:
               pg-version: pg17
             pg:
-              version: 17.0
+              version: "17.0"
     steps:
       - uses: actions/checkout@v3
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,32 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.2.4] - 2024-10-01
+
+### Bug Fixes
+
+- Trigger settings
+- Add explicit pgrx_embed bin
+
+### Features
+
+- Add note to docs about CI issues
+- Add postgres 17
+
+### Miscellaneous Tasks
+
+- Update deps
+- Pg 15.6 -> 15.8
+- Pg 16.2 -> 16.4
+- Pgrx 0.11.3 -> 0.12.5
+- Update rust version
+- Update pgrx init version, print pgrx version
+- Remove automated PR testing for pg12/pg13
+
+### Refactor
+
+- Update chrono usage
+
 ## [0.2.3] - 2024-03-06
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "pg_idkit"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "chrono",
  "cuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg_idkit"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 authors = ["Victor Adossi <vados@vadosware.io>"]
 license = "MIT"
@@ -66,7 +66,7 @@ assets = []
 [package.metadata.generate-rpm.variants.pg12]
 assets = [
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/lib/postgresql/pg_idkit.so", dest = "/usr/lib64/pgsql/pg_idkit.so", mode = "755" },
-  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.2.3.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.2.3.sql", mode = "755" },
+  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.2.4.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.2.4.sql", mode = "755" },
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit.control", dest = "/usr/share/pgsql/extension/pg_idkit.control", mode = "755" },
 ]
 requires = { postgresql-server = "> 12", glibc = "*" }
@@ -75,7 +75,7 @@ release = "pg12"
 [package.metadata.generate-rpm.variants.pg13]
 assets = [
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/lib/postgresql/pg_idkit.so", dest = "/usr/lib64/pgsql/pg_idkit.so", mode = "755" },
-  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.2.3.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.2.3.sql", mode = "755" },
+  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.2.4.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.2.4.sql", mode = "755" },
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit.control", dest = "/usr/share/pgsql/extension/pg_idkit.control", mode = "755" },
 ]
 requires = { postgresql-server = "> 13", glibc = "*" }
@@ -84,7 +84,7 @@ release = "pg13"
 [package.metadata.generate-rpm.variants.pg14]
 assets = [
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/lib/postgresql/pg_idkit.so", dest = "/usr/lib64/pgsql/pg_idkit.so", mode = "755" },
-  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.2.3.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.2.3.sql", mode = "755" },
+  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.2.4.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.2.4.sql", mode = "755" },
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit.control", dest = "/usr/share/pgsql/extension/pg_idkit.control", mode = "755" },
 ]
 requires = { postgresql-server = "> 14", glibc = "*" }
@@ -93,7 +93,7 @@ release = "pg14"
 [package.metadata.generate-rpm.variants.pg15]
 assets = [
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/lib/postgresql/pg_idkit.so", dest = "/usr/lib64/pgsql/pg_idkit.so", mode = "755" },
-  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.2.3.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.2.3.sql", mode = "755" },
+  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.2.4.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.2.4.sql", mode = "755" },
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit.control", dest = "/usr/share/pgsql/extension/pg_idkit.control", mode = "755" },
 ]
 requires = { postgresql-server = "> 15", glibc = "*" }
@@ -102,7 +102,7 @@ release = "pg15"
 [package.metadata.generate-rpm.variants.pg16]
 assets = [
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/lib/postgresql/pg_idkit.so", dest = "/usr/lib64/pgsql/pg_idkit.so", mode = "755" },
-  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.2.3.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.2.3.sql", mode = "755" },
+  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.2.4.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.2.4.sql", mode = "755" },
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit.control", dest = "/usr/share/pgsql/extension/pg_idkit.control", mode = "755" },
 ]
 requires = { postgresql-server = "> 16", glibc = "*" }
@@ -111,7 +111,7 @@ release = "pg16"
 [package.metadata.generate-rpm.variants.pg17]
 assets = [
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/lib/postgresql/pg_idkit.so", dest = "/usr/lib64/pgsql/pg_idkit.so", mode = "755" },
-  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.2.3.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.2.3.sql", mode = "755" },
+  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.2.4.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.2.4.sql", mode = "755" },
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit.control", dest = "/usr/share/pgsql/extension/pg_idkit.control", mode = "755" },
 ]
 requires = { postgresql-server = "> 17", glibc = "*" }

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ docker run \
     -e POSTGRES_PASSWORD=replace_this \
     -p 5432 \
     --name pg_idkit \
-    ghcr.io/vadosware/pg_idkit:0.2.3-pg16.2-alpine3.18-amd64
+    ghcr.io/vadosware/pg_idkit:0.2.4-pg17.0-alpine3.18-amd64
 ```
 
 > [!WARNING]
@@ -77,7 +77,7 @@ Once the postgres server is running, open another shell and connect to the docke
 
 ```console
 ➜ docker exec -it pg_idkit psql -U postgres
-psql (16.2)
+psql (17.0)
 Type "help" for help.
 
 postgres=# CREATE EXTENSION pg_idkit;
@@ -111,7 +111,7 @@ target/release/pg_idkit-pg16
 ├── home
 │   └── <user>
 │       └── .pgrx
-│           └── 16.2
+│           └── 17.0
 │               └── pgrx-install
 │                   ├── lib
 │                   │   └── postgresql
@@ -119,7 +119,7 @@ target/release/pg_idkit-pg16
 │                   └── share
 │                       └── postgresql
 │                           └── extension
-│                               ├── pg_idkit--0.2.3.sql
+│                               ├── pg_idkit--0.2.4.sql
 │                               └── pg_idkit.control
 └── usr
     ├── lib
@@ -137,9 +137,9 @@ As the installation of the extension into a specific version of postgres uses yo
 
 In the example above, the [files you need for a Postgres extension][pg-ext-files] are:
 
-- `target/release/home/<user>/.pgrx/16.2/pgrx-install/lib/postgresql/pg_idkit.so`
-- `target/release/home/<user>/.pgrx/16.2/pgrx-install/share/postgresql/extension/pg_idkit--0.2.3.sql`
-- `target/release/home/<user>/.pgrx/16.2/pgrx-install/share/postgresql/extension/pg_idkit.control`
+- `target/release/home/<user>/.pgrx/17.0/pgrx-install/lib/postgresql/pg_idkit.so`
+- `target/release/home/<user>/.pgrx/17.0/pgrx-install/share/postgresql/extension/pg_idkit--0.2.4.sql`
+- `target/release/home/<user>/.pgrx/17.0/pgrx-install/share/postgresql/extension/pg_idkit.control`
 
 Install these files in the relevant folders for your Postgres installation -- note that exactly where these files should go can can differ across linux distributions and containerized environments.
 
@@ -185,14 +185,14 @@ docker run \
     -e POSTGRES_PASSWORD=replace_this \
     -p 5432 \
     --name pg_idkit \
-    ghcr.io/vadosware/pg_idkit:0.2.3-pg16.2-alpine3.18-amd64
+    ghcr.io/vadosware/pg_idkit:0.2.4-pg17.0-alpine3.18-amd64
 ```
 
 From another terminal, you can exec into the `pg_idkit` container and enable `pg_idkit`:
 
 ```console
 ➜ docker exec -it pg_idkit psql -U postgres
-psql (16.2)
+psql (17.0)
 Type "help" for help.
 
 postgres=# CREATE EXTENSION pg_idkit;
@@ -222,10 +222,10 @@ RPMs are produced upon [every official release](/releases) of `pg_idkit`.
 
 Grab a released version of the RPM (or build one yourself by running `just build-rpm` after [setting up local development][guide-localdev]).
 
-For example, with an RPM named `pg_idkit-0.2.3-pg16.x86_64.rpm`, you should be able to run:
+For example, with an RPM named `pg_idkit-0.2.4-pg17.x86_64.rpm`, you should be able to run:
 
 ```
-dnf install pg_idkit-0.2.3-pg16.x86_64.rpm
+dnf install pg_idkit-0.2.4-pg17.x86_64.rpm
 ```
 
 </details>


### PR DESCRIPTION
This is a release prep branch for `pg_idkit` release v0.2.4.

Upon merging, this branch will cause a tag to be placed on the commit in `main`. After the tag has been placed, a build will run that generates artifacts and publishes a release.

Before this release is ready, here is the checklist:
  - [x] Update the examples in `README.md` to use the newest version
  - [x] Update `generate-rpm` configuration in `Cargo.toml` version references (ex. `--0.2.0.sql` -> `--0.2.1.sql`)

See CHANGELOG for changes made to this release before it goes out.