### PR TITLE
Added CUID2 custom length 

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ postgres=# SELECT idkit_uuidv7_generate();
 | [cuid][cuid] (deprecated) | `idkit_cuid_generate()`                     | [`cuid`][crate-cuid]                 | CUID                                                     |
 |                           | `idkit_cuid_extract_timestamptz(TEXT)`      |                                      |                                                          |
 | [cuid2][cuid2]            | `idkit_cuid2_generate()`                    | [`cuid2`][crate-cuid2]               | CUID2                                                    |
+|                           | `idkit_cuid2_custom_generate(length)`       |                                      | CUID2 with custom length                                |
 
 This Postgres extension is made possible thanks to [`pgrx`][pgrx].
 

--- a/src/cuid2.rs
+++ b/src/cuid2.rs
@@ -6,6 +6,28 @@ fn idkit_cuid2_generate() -> String {
     cuid2::create_id()
 }
 
+/// Generate a custom cuid2 UUID with specified length
+#[pg_extern]
+fn idkit_cuid2_custom_generate(length: i32) -> Result<String, String> {
+    if length < 2 {
+        return Err("CUID2 length must be at least 2".to_string());
+    }
+    if length > u16::MAX as i32 {
+        return Err(format!("CUID2 length must be at most {}", u16::MAX));
+    }
+    
+    let constructor = cuid2::CuidConstructor::new().with_length(length as u16);
+    
+    // Note: Custom fingerprint support is not currently implemented because 
+    // the cuid2 library expects function pointers for fingerprinters, not 
+    // string values. This would require either:
+    // 1. Implementing CUID2 generation logic directly to use custom fingerprints
+    // 2. Using a different library that supports string-based fingerprints
+    // 3. Creating a wrapper that modifies the generated ID based on the fingerprint
+    
+    Ok(constructor.create_id())
+}
+
 /// Generate a random cuid UUID, producing a Postgres text object
 #[pg_extern]
 fn idkit_cuid2_generate_text() -> String {
@@ -26,5 +48,33 @@ mod tests {
     fn test_cuid2_len() {
         let generated = crate::cuid2::idkit_cuid2_generate();
         assert_eq!(generated.len(), 24);
+    }
+
+    /// Test custom length generation
+    #[pg_test]
+    fn test_cuid2_custom_length() {
+        let generated = crate::cuid2::idkit_cuid2_custom_generate(16).unwrap();
+        assert_eq!(generated.len(), 16);
+        
+        let generated_32 = crate::cuid2::idkit_cuid2_custom_generate(32).unwrap();
+        assert_eq!(generated_32.len(), 32);
+    }
+
+    /// Test invalid length handling
+    #[pg_test]
+    fn test_cuid2_invalid_length() {
+        let result = crate::cuid2::idkit_cuid2_custom_generate(1);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("must be at least 2"));
+    }
+
+    /// Test that generated IDs are valid CUID2s
+    #[pg_test]
+    fn test_cuid2_validity() {
+        let generated = crate::cuid2::idkit_cuid2_generate();
+        assert!(cuid2::is_cuid2(&generated));
+
+        let generated_custom = crate::cuid2::idkit_cuid2_custom_generate(16).unwrap();
+        assert!(cuid2::is_cuid2(&generated_custom));
     }
 }


### PR DESCRIPTION
I added the ability to add a custom length for CUID2 ids. This is supported in the `cuid2` crate, [here](https://github.com/mplanchard/cuid-rust/tree/master/crates/cuid2).

With these changes, there's the original function:

```psql
pg_idkit=# SELECT idkit_cuid2_generate();
   idkit_cuid2_generate
--------------------------
 k5024qz6xit7o9jlzabvbwxk
(1 row)
```

And a new, `idkit_cuid2_custom_generate`, which takes a length.

```psql
pg_idkit=# SELECT idkit_cuid2_custom_generate(12);
 idkit_cuid2_custom_generate
-----------------------------
 a6ljat3o3tum
(1 row)

pg_idkit=# SELECT idkit_cuid2_custom_generate(12);
 idkit_cuid2_custom_generate
-----------------------------
 zp3s7x1i7alb
(1 row)
```

(I followed the same pattern as how nanoID is implemented.)

## Why not the other custom properties?

The reference [cuid2](https://github.com/paralleldrive/cuid2?tab=readme-ov-file) implementation allows for custom length (as well as random source and fingerprint). However, the rust implementation requires a function pointer, and I'm not really a rust developer; I just really want to use `CUID2` in postgres. So, I left a comment that matched my understanding. It can always be expanded in the future.