### PR TITLE
release: pg_idkit v0.3.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,25 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.3.1] - 2025-07-19
+
+### Features
+
+- Add typeid support (#112)
+
+- Added CUID2 custom length (#111)
+
+### Miscellaneous Tasks
+
+- Bump uuid from 1.16.0 to 1.17.0
+- Bump softprops/action-gh-release from 2.2.1 to 2.2.2 (#99)
+- Bump actions/download-artifact from 4.2.1 to 4.3.0 (#100)
+- Bump softprops/action-gh-release from 2.2.2 to 2.3.2 (#103)
+- Bump taiki-e/cache-cargo-install-action from 2.1.1 to 2.1.2 (#104)
+- Bump Swatinem/rust-cache from 2.7.8 to 2.8.0 (#105)
+- Bump taiki-e/cache-cargo-install-action from 2.1.2 to 2.2.0 (#106)
+- Update pgrx to 0.15.0 (#109)
+
 ## [0.3.0] - 2025-05-21
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "pg_idkit"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg_idkit"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Victor Adossi <vados@vadosware.io>"]
 license = "MIT"
@@ -68,7 +68,7 @@ assets = []
 [package.metadata.generate-rpm.variants.pg13]
 assets = [
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/lib/postgresql/pg_idkit.so", dest = "/usr/lib64/pgsql/pg_idkit.so", mode = "755" },
-  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.3.0.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.3.0.sql", mode = "755" },
+  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.3.1.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.3.1.sql", mode = "755" },
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit.control", dest = "/usr/share/pgsql/extension/pg_idkit.control", mode = "755" },
 ]
 requires = { postgresql-server = "> 13", glibc = "*" }
@@ -77,7 +77,7 @@ release = "pg13"
 [package.metadata.generate-rpm.variants.pg14]
 assets = [
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/lib/postgresql/pg_idkit.so", dest = "/usr/lib64/pgsql/pg_idkit.so", mode = "755" },
-  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.3.0.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.3.0.sql", mode = "755" },
+  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.3.1.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.3.1.sql", mode = "755" },
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit.control", dest = "/usr/share/pgsql/extension/pg_idkit.control", mode = "755" },
 ]
 requires = { postgresql-server = "> 14", glibc = "*" }
@@ -86,7 +86,7 @@ release = "pg14"
 [package.metadata.generate-rpm.variants.pg15]
 assets = [
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/lib/postgresql/pg_idkit.so", dest = "/usr/lib64/pgsql/pg_idkit.so", mode = "755" },
-  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.3.0.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.3.0.sql", mode = "755" },
+  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.3.1.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.3.1.sql", mode = "755" },
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit.control", dest = "/usr/share/pgsql/extension/pg_idkit.control", mode = "755" },
 ]
 requires = { postgresql-server = "> 15", glibc = "*" }
@@ -95,7 +95,7 @@ release = "pg15"
 [package.metadata.generate-rpm.variants.pg16]
 assets = [
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/lib/postgresql/pg_idkit.so", dest = "/usr/lib64/pgsql/pg_idkit.so", mode = "755" },
-  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.3.0.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.3.0.sql", mode = "755" },
+  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.3.1.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.3.1.sql", mode = "755" },
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit.control", dest = "/usr/share/pgsql/extension/pg_idkit.control", mode = "755" },
 ]
 requires = { postgresql-server = "> 16", glibc = "*" }
@@ -104,7 +104,7 @@ release = "pg16"
 [package.metadata.generate-rpm.variants.pg17]
 assets = [
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/lib/postgresql/pg_idkit.so", dest = "/usr/lib64/pgsql/pg_idkit.so", mode = "755" },
-  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.3.0.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.3.0.sql", mode = "755" },
+  { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit--0.3.1.sql", dest = "/usr/share/pgsql/extension/pg_idkit--0.3.1.sql", mode = "755" },
   { source = "/tmp/pg_idkit/rpm/scratch/pgrx-install/share/postgresql/extension/pg_idkit.control", dest = "/usr/share/pgsql/extension/pg_idkit.control", mode = "755" },
 ]
 requires = { postgresql-server = "> 17", glibc = "*" }

--- a/Justfile
+++ b/Justfile
@@ -71,7 +71,7 @@ _check-installed-version tool msg:
 # Build #
 #########
 
-version := env_var_or_default("VERSION", "0.3.0")
+version := env_var_or_default("VERSION", "0.3.1")
 
 # Print the current version (according to the script)
 [group('meta')]

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ docker run \
     -e POSTGRES_PASSWORD=replace_this \
     -p 5432 \
     --name pg_idkit \
-    ghcr.io/vadosware/pg_idkit:0.3.0-pg17.5-alpine3.21.3-amd64
+    ghcr.io/vadosware/pg_idkit:0.3.1-pg17.5-alpine3.21.3-amd64
 ```
 
 > [!WARNING]
@@ -125,7 +125,7 @@ target/release/pg_idkit-pg17
 │                   └── share
 │                       └── postgresql
 │                           └── extension
-│                               ├── pg_idkit--0.3.0.sql
+│                               ├── pg_idkit--0.3.1.sql
 │                               └── pg_idkit.control
 └── usr
     ├── lib
@@ -144,7 +144,7 @@ As the installation of the extension into a specific version of postgres uses yo
 In the example above, the [files you need for a Postgres extension][pg-ext-files] are:
 
 - `target/release/home/<user>/.pgrx/17.5/pgrx-install/lib/postgresql/pg_idkit.so`
-- `target/release/home/<user>/.pgrx/17.5/pgrx-install/share/postgresql/extension/pg_idkit--0.3.0.sql`
+- `target/release/home/<user>/.pgrx/17.5/pgrx-install/share/postgresql/extension/pg_idkit--0.3.1.sql`
 - `target/release/home/<user>/.pgrx/17.5/pgrx-install/share/postgresql/extension/pg_idkit.control`
 
 Install these files in the relevant folders for your Postgres installation -- note that exactly where these files should go can can differ across linux distributions and containerized environments.
@@ -191,7 +191,7 @@ docker run \
     -e POSTGRES_PASSWORD=replace_this \
     -p 5432 \
     --name pg_idkit \
-    ghcr.io/vadosware/pg_idkit:0.3.0-pg17.5-alpine3.18-amd64
+    ghcr.io/vadosware/pg_idkit:0.3.1-pg17.5-alpine3.18-amd64
 ```
 
 From another terminal, you can exec into the `pg_idkit` container and enable `pg_idkit`:
@@ -228,10 +228,10 @@ RPMs are produced upon [every official release](/releases) of `pg_idkit`.
 
 Grab a released version of the RPM (or build one yourself by running `just build-rpm` after [setting up local development][guide-localdev]).
 
-For example, with an RPM named `pg_idkit-0.3.0-pg17.x86_64.rpm`, you should be able to run:
+For example, with an RPM named `pg_idkit-0.3.1-pg17.x86_64.rpm`, you should be able to run:
 
 ```
-dnf install pg_idkit-0.3.0-pg17.x86_64.rpm
+dnf install pg_idkit-0.3.1-pg17.x86_64.rpm
 ```
 
 </details>


### PR DESCRIPTION
This is a release prep branch for `pg_idkit` release v0.3.1.

Upon merging, this branch will cause a tag to be placed on the commit in `main`. After the tag has been placed, a build will run that generates artifacts and publishes a release.

Before this release is ready, here is the checklist:
  - [x] Update `README.md` to use the newest version of Postgres, if it has changed (ex. `16.2` -> `17.0`)
  - [x] Update `README.md` to soon-to-be-released pg_idkit (ex. `pg_idkit-0.2.0` -> `pg_idkit-0.2.1`)
  - [x] Update `generate-rpm` configuration in `Cargo.toml` version references (ex. `--0.2.0.sql` -> `--0.2.1.sql`)
  - [x] Update default version in `justfile`

See CHANGELOG for changes made to this release before it goes out.